### PR TITLE
fix: :bug: yarn v4 Replace prepare script with postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "prepublishOnly": "napi prepublish -t npm --skip-gh-release",
     "test": "ava",
     "bump": "node scripts/bump.mjs",
-    "prepare": "husky install"
+    "postinstall": "husky install"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.7",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "prepublishOnly": "napi prepublish -t npm --skip-gh-release",
     "test": "ava",
     "bump": "node scripts/bump.mjs",
-    "postinstall": "husky install"
+    "postinstall": "husky"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.7",


### PR DESCRIPTION
该项目锁定yarn版本为yarn-4.3.1，需使用postinstall，且高版本husky install需要修改为husky